### PR TITLE
Fix OSError in DRM enumerator

### DIFF
--- a/screeninfo/screeninfo.py
+++ b/screeninfo/screeninfo.py
@@ -362,7 +362,7 @@ def _enumerate_drm():
                 crtc = connector.encoder.crtc
                 monitors.append(
                     Monitor(crtc.x, crtc.y, crtc.width, crtc.height))
-        os.close(card_no)
+        os.close(fd)
 
     return monitors
 


### PR DESCRIPTION
The file descriptor opened was being incorrectly referred to as `card_no` whereas the actual file descriptor is stored in `fd`. Led to an error when the file descriptor was closed.