### PR TITLE
Remove default values for Monitor

### DIFF
--- a/screeninfo/screeninfo.py
+++ b/screeninfo/screeninfo.py
@@ -3,11 +3,6 @@ import os
 
 class Monitor(object):
     """Stores the resolution and position of a monitor."""
-    x = 0
-    y = 0
-    width = 0
-    height = 0
-
     def __init__(self, x, y, width, height):
         self.x = x
         self.y = y


### PR DESCRIPTION
Instances of `Monitor` have their resolution and position set during initialization, which means default values are not needed.

This change will help prevent users accidentally using `Monitor` as a static class, as `screeninfo.Monitor.x` will no longer return `0`.