### PR TITLE
Fix inconsistent type error

### DIFF
--- a/screeninfo/enumerators/osx.py
+++ b/screeninfo/enumerators/osx.py
@@ -16,8 +16,8 @@ def enumerate_monitors() -> T.Iterable[Monitor]:
             f = f()
 
         yield Monitor(
-            x=f.origin.x,
-            y=f.origin.y,
-            width=f.size.width,
-            height=f.size.height,
+            x=int(f.origin.x),
+            y=int(f.origin.y),
+            width=int(f.size.width),
+            height=int(f.size.height),
         )


### PR DESCRIPTION
`CGRect` returned by `NSScreen::frame` may have `floating` value inside it.
It causes type inconsistent problem with `Monitor` class in `screeninfo`.
https://developer.apple.com/documentation/coregraphics/cgrect