### PR TITLE
setup.py: Add screeninfo.enumerators to packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name="screeninfo",
-    packages=["screeninfo"],
+    packages=["screeninfo", "screeninfo.enumerators"],
     version="0.3.1",
     description="Fetch location and size of physical screens.",
     author="rr-",


### PR DESCRIPTION
This adds the enumerators subdirectory to the sdist, which is needed when packaging screeninfo for some Linux distributions.
