### PR TITLE
Monitor physical size reporting in millimeters

### DIFF
--- a/screeninfo/common.py
+++ b/screeninfo/common.py
@@ -11,6 +11,8 @@ class Monitor:
     y: int
     width: int
     height: int
+    width_mm: T.Optional[int] = 0
+    height_mm: T.Optional[int] = 0
     name: T.Optional[str] = None
 
     def __repr__(self) -> str:
@@ -18,6 +20,7 @@ class Monitor:
             f"Monitor("
             f"x={self.x}, y={self.y}, "
             f"width={self.width}, height={self.height}, "
+            f"width_mm={self.width_mm}, height_mm={self.height_mm}, "
             f"name={self.name!r}"
             f")"
         )

--- a/screeninfo/common.py
+++ b/screeninfo/common.py
@@ -11,8 +11,8 @@ class Monitor:
     y: int
     width: int
     height: int
-    width_mm: T.Optional[int] = 0
-    height_mm: T.Optional[int] = 0
+    width_mm: T.Optional[int] = None
+    height_mm: T.Optional[int] = None
     name: T.Optional[str] = None
 
     def __repr__(self) -> str:

--- a/screeninfo/enumerators/windows.py
+++ b/screeninfo/enumerators/windows.py
@@ -67,6 +67,6 @@ def enumerate_monitors() -> T.Iterable[Monitor]:
     # We want monitor specific DCs in the callback.
     ctypes.windll.user32.EnumDisplayMonitors(
         dc_full, None, MonitorEnumProc(callback), 0
-        )
+    )
 
     yield from monitors

--- a/screeninfo/enumerators/windows.py
+++ b/screeninfo/enumerators/windows.py
@@ -8,6 +8,9 @@ def enumerate_monitors() -> T.Iterable[Monitor]:
     import ctypes.wintypes
 
     CCHDEVICENAME = 32
+    # gdi32.GetDeviceCaps keys for monitor size in mm
+    HORZSIZE = 4
+    VERTSIZE = 6
 
     MonitorEnumProc = ctypes.WINFUNCTYPE(
         ctypes.c_int,
@@ -36,6 +39,9 @@ def enumerate_monitors() -> T.Iterable[Monitor]:
         else:
             name = None
 
+        h_size = ctypes.windll.gdi32.GetDeviceCaps(dc, HORZSIZE)
+        v_size = ctypes.windll.gdi32.GetDeviceCaps(dc, VERTSIZE)
+
         rct = rect.contents
         monitors.append(
             Monitor(
@@ -43,13 +49,24 @@ def enumerate_monitors() -> T.Iterable[Monitor]:
                 y=rct.top,
                 width=rct.right - rct.left,
                 height=rct.bottom - rct.top,
+                width_mm=h_size,
+                height_mm=v_size,
                 name=name,
             )
         )
         return 1
 
+    # Make the process DPI aware so it will detect the actual
+    # resolution and not a virtualized resolution reported by
+    # Windows when DPI virtualization is in use.
+    ctypes.windll.user32.SetProcessDPIAware()
+    # Create a Device Context for the full virtual desktop.
+    dc_full = ctypes.windll.user32.GetDC(None)
+    # Call EnumDisplayMonitors with the non-NULL DC
+    # so that non-NULL DCs are passed onto the callback.
+    # We want monitor specific DCs in the callback.
     ctypes.windll.user32.EnumDisplayMonitors(
-        0, 0, MonitorEnumProc(callback), 0
-    )
+        dc_full, None, MonitorEnumProc(callback), 0
+        )
 
     yield from monitors

--- a/screeninfo/enumerators/xrandr.py
+++ b/screeninfo/enumerators/xrandr.py
@@ -104,6 +104,8 @@ def enumerate_monitors() -> T.Iterable[Monitor]:
                         y=crtc_info.contents.y,
                         width=crtc_info.contents.width,
                         height=crtc_info.contents.height,
+                        width_mm=output_info.contents.mm_width,
+                        height_mm=output_info.contents.mm_height,
                         name=output_info.contents.name.decode(
                             sys.getfilesystemencoding()
                         ),


### PR DESCRIPTION
Extend the base Monitor class to accept the data, width_mm, height_mm.
Implement the reporting for windows and xrandr enumerators.
Windows changes were less obvious so I tried to comment on the changes I did.
I also fixed an issue on Windows where screeninfo would report incorrect resolutions if HiDPI scaling options were in use. This was resolved by making the application DPI aware by calling "ctypes.windll.user32.SetProcessDPIAware()".