### PR TITLE
fix 'No enumerators available' - on Windows 10

### DIFF
--- a/screeninfo/enumerators/windows.py
+++ b/screeninfo/enumerators/windows.py
@@ -64,28 +64,38 @@ def enumerate_monitors() -> T.Iterable[Monitor]:
     # multiple monitors have different DPIs.
     ctypes.windll.shcore.SetProcessDpiAwareness(2)
 
+    # Type of HWND resolves to void *
+    # HWND -> HANDLE -> PVOID -> void *
+    # See https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types
+    hwnd = ctypes.c_void_p(None)
     # On Python 3.8.X GetDC randomly fails returning an invalid DC.
     # To workaround this request a number of DCs until a valid DC is returned.
     for retry in range(100):
         # Create a Device Context for the full virtual desktop.
-        dc_full = ctypes.windll.user32.GetDC(None)
-        if dc_full > 0:
+        # On failure, GetDC returns NULL (type: HDC)
+        # HDC eventually resolves to void *
+        # HDC -> HANDLE -> PVOID -> void *
+        # See https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types
+        GetDC = ctypes.windll.user32.GetDC
+        GetDC.restype = ctypes.c_void_p
+        dc_full = GetDC(hwnd)
+        if dc_full is not None:
             # Got a valid DC, break.
             break
-        ctypes.windll.user32.ReleaseDC(dc_full)
+        ctypes.windll.user32.ReleaseDC(hwnd, dc_full)
     else:
         # Fallback to device context 0 that is the whole
         # desktop. This allows fetching resolutions
         # but monitor specific device contexts are not
         # passed to the callback which means that physical
         # sizes can't be read.
-        dc_full = 0
+        dc_full = ctypes.c_void_p(None)
     # Call EnumDisplayMonitors with the non-NULL DC
     # so that non-NULL DCs are passed onto the callback.
     # We want monitor specific DCs in the callback.
     ctypes.windll.user32.EnumDisplayMonitors(
         dc_full, None, MonitorEnumProc(callback), 0
     )
-    ctypes.windll.user32.ReleaseDC(dc_full)
+    ctypes.windll.user32.ReleaseDC(hwnd, dc_full)
 
     yield from monitors


### PR DESCRIPTION
Fixes #30

`dc_full` is a pointer, if interpretted as a signed number may it be negative despite the call to `GetDC` being successful.

Failure is indicated by `NULL` -> `0`. This PR sets the return type for the foriegn function `GetDC` so the value can be compared to None.

- See `GetDC` docs: https://docs.microsoft.com/en-gb/windows/win32/api/winuser/nf-winuser-getdc
- See Windows types: https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types

ReleaseDC was not being called with enough arguments, it should also
take the same Window Handle (HWND) as GetDC.
- See `ReleaseDC` docs: https://docs.microsoft.com/en-gb/windows/win32/api/winuser/nf-winuser-releasedc