### PR TITLE
Update requirements necessary on Darwin platforms

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,9 @@ setup(
     url="https://github.com/rr-/screeninfo",
     keywords=["screen", "monitor", "desktop"],
     classifiers=[],
-    install_requires=["dataclasses"],
+    install_requires=[
+        "dataclasses",
+        'Cython ; platform_system=="darwin"',
+        'pyobjus ; platform_system=="darwin"',
+    ],
 )


### PR DESCRIPTION
Should fix "No enumerators available" - on macOS #27, I have not tested yet. However manually installing Cython and then pyobjus makes get_monitors() return successfully on OS X.
>>> from screeninfo import get_monitors, Enumerator
>>> for m in get_monitors(Enumerator.OSX):
...   print(str(m))
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/screeninfo/screeninfo.py", line 29, in get_monitors
    return _get_monitors(enumerator)
  File "/usr/local/lib/python3.7/site-packages/screeninfo/screeninfo.py", line 19, in _get_monitors
    return list(ENUMERATOR_MAP[enumerator].enumerate_monitors())
  File "/usr/local/lib/python3.7/site-packages/screeninfo/enumerators/osx.py", line 7, in enumerate_monitors
    from pyobjus import autoclass
ModuleNotFoundError: No module named 'pyobjus'