### PR TITLE
Update requirements necessary on Darwin platform, correctly this time.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name="screeninfo",
@@ -12,7 +12,7 @@ setup(
     classifiers=[],
     install_requires=[
         "dataclasses",
-        'Cython ; platform_system=="darwin"',
-        'pyobjus ; platform_system=="darwin"',
+        'Cython ; sys_platform=="darwin"',
+        'pyobjus ; sys_platform=="darwin"',
     ],
 )


### PR DESCRIPTION
Now I've actually tested the code change I submitted as untested in PR #33 which didn't do anything :) This has been tested and works to install Cython and pyobjus as requirements.

$ pip3 install -e . --user
Obtaining file:///Users/joshboyd/Code/screeninfo
Requirement already satisfied: dataclasses in /usr/local/lib/python3.7/site-packages (from screeninfo==0.6.4) (0.6)
Requirement already satisfied: Cython in /usr/local/lib/python3.7/site-packages (from screeninfo==0.6.4) (0.29.16)
Requirement already satisfied: pyobjus in /usr/local/lib/python3.7/site-packages (from screeninfo==0.6.4) (1.1.0)
Installing collected packages: screeninfo
  Attempting uninstall: screeninfo
    Found existing installation: screeninfo 0.6.4
    Uninstalling screeninfo-0.6.4:
      Successfully uninstalled screeninfo-0.6.4
  Running setup.py develop for screeninfo
Successfully installed screeninfo