### PR TITLE
Pull dataclasses only when really needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     keywords=["screen", "monitor", "desktop"],
     classifiers=[],
     install_requires=[
-        "dataclasses",
+        "dataclasses ; python_version<'3.7'",
         'Cython ; sys_platform=="darwin"',
         'pyobjus ; sys_platform=="darwin"',
     ],


### PR DESCRIPTION
This package is part of core python on 3.7 and newer.