### PR TITLE
OSX: Replace pyobjus with AppKit

### DIFF
--- a/screeninfo/enumerators/osx.py
+++ b/screeninfo/enumerators/osx.py
@@ -4,15 +4,12 @@ from screeninfo.common import Monitor
 
 
 def enumerate_monitors() -> T.Iterable[Monitor]:
-    from pyobjus import autoclass
-    from pyobjus.dylib_manager import INCLUDE, load_framework
+    from AppKit import NSScreen
 
-    load_framework(INCLUDE.AppKit)
+    screens = NSScreen.screens()
 
-    screens = autoclass("NSScreen").screens()
-
-    for i in range(screens.count()):
-        f = screens.objectAtIndex_(i).frame
+    for screen in screens:
+        f = screen.frame
         if callable(f):
             f = f()
 

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,6 @@ setup(
     install_requires=[
         "dataclasses ; python_version<'3.7'",
         'Cython ; sys_platform=="darwin"',
+        'pyobjc-framework-Cocoa ; sys_platform=="darwin"',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,5 @@ setup(
     install_requires=[
         "dataclasses ; python_version<'3.7'",
         'Cython ; sys_platform=="darwin"',
-        'pyobjus ; sys_platform=="darwin"',
     ],
 )


### PR DESCRIPTION
Simplifies codebase a little bit by using AppKit directly instead of pyobjus' `load_framework(INCLUDE.AppKit)`.

This also fixes an obscure bug in [Evidlo/remarkable_mouse](https://github.com/Evidlo/remarkable_mouse), where this library conflicts with pynput. See https://github.com/Evidlo/remarkable_mouse/issues/39#issuecomment-724950557