### PR TITLE
Added get_primary to screeninfo and exposed it from __init__.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-screeninfo
-----------
+# screeninfo
 
 [![Build](https://github.com/rr-/screeninfo/actions/workflows/build.yml/badge.svg)](https://github.com/rr-/screeninfo/actions/workflows/build.yml)
 
 Fetch location and size of physical screens.
 
-### Supported environments
+## Supported environments
 
 - MS Windows
 - MS Windows: Cygwin
@@ -16,7 +15,7 @@ Fetch location and size of physical screens.
 I don't plan on testing OSX or other environments myself. For this reason,
 I strongly encourage pull requests.
 
-### Installation
+## Installation
 
 ```
 pip install screeninfo
@@ -28,22 +27,43 @@ If you install it from sources:
 python3 setup.py install
 ```
 
-### Usage
+## Usage
+
+### Get all monitors
 
 ```python
 from screeninfo import get_monitors
+
 for m in get_monitors():
     print(str(m))
 ```
 
-**Output**:
+#### Output
 
-```python console
+```pycon
 Monitor(x=3840, y=0, width=3840, height=2160, width_mm=1420, height_mm=800, name='HDMI-0', is_primary=False)
 Monitor(x=0, y=0, width=3840, height=2160, width_mm=708, height_mm=399, name='DP-0', is_primary=True)
 ```
 
-### Forcing environment
+### Get primary monitor
+
+```python
+from screeninfo import get_primary
+
+width, height = get_primary()
+
+print("width:", width)
+print("height:", height)
+```
+
+#### Output
+
+```pycon
+width: 2560
+height: 1440
+```
+
+## Forcing environment
 
 In some cases (emulating X server on Cygwin etc.) you might want to specify the
 driver directly. You can do so by passing extra parameter to `get_monitors()`
@@ -57,7 +77,7 @@ for m in get_monitors(Enumerator.OSX):
 
 Available drivers: `windows`, `cygwin`, `x11`, `osx`.
 
-# Contributing
+## Contributing
 
 This project uses [precommit](https://pre-commit.com/). You can install it with
 `python3 -m pip install --user pre-commit` and running `pre-commit install`.

--- a/screeninfo/__init__.py
+++ b/screeninfo/__init__.py
@@ -1,2 +1,2 @@
 from .common import Enumerator, Monitor
-from .screeninfo import get_monitors
+from .screeninfo import get_monitors, get_primary

--- a/screeninfo/screeninfo.py
+++ b/screeninfo/screeninfo.py
@@ -38,7 +38,7 @@ def get_monitors(
 def get_primary() -> T.Tuple[int, int]:
     """Returns a tuple of (width, height) of your primary monitor."""
 
-    primary = list(map(lambda monitor: (monitor.width, monitor.height), filter(lambda monitor: monitor.is_primary, get_monitors())))
+    primary = list(map(lambda m: (m.width, m.height), filter(lambda m: m.is_primary, get_monitors())))
 
     if primary:
         return tuple(primary[0])

--- a/screeninfo/screeninfo.py
+++ b/screeninfo/screeninfo.py
@@ -38,4 +38,9 @@ def get_monitors(
 def get_primary() -> T.Tuple[int, int]:
     """Returns a tuple of (width, height) of your primary monitor."""
 
-    return tuple(list(map(lambda monitor: (monitor.width, monitor.height), filter(lambda monitor: monitor.is_primary, get_monitors())))[0])
+    primary = list(map(lambda monitor: (monitor.width, monitor.height), filter(lambda monitor: monitor.is_primary, get_monitors())))
+
+    if primary:
+        return tuple(primary[0])
+
+    return tuple(0, 0)

--- a/screeninfo/screeninfo.py
+++ b/screeninfo/screeninfo.py
@@ -33,3 +33,9 @@ def get_monitors(
             pass
 
     raise ScreenInfoError("No enumerators available")
+
+
+def get_primary() -> T.Tuple[int, int]:
+    """Returns a tuple of (width, height) of your primary monitor."""
+
+    return tuple(list(map(lambda monitor: (monitor.width, monitor.height), filter(lambda monitor: monitor.is_primary, get_monitors())))[0])

--- a/screeninfo/test_screeninfo.py
+++ b/screeninfo/test_screeninfo.py
@@ -25,7 +25,9 @@ def test_get_monitors_has_at_least_one_monitor():
 
 def test_get_primary_does_not_raise():
     with not_raises(Exception):
-        assert (get_primary()[0] * 0, get_primary()[1] * 0) == (0, 0)
+        primary = get_primary()
+
+        assert (primary[0] * 0, primary[1] * 0) == (0, 0)
 
 
 def test_get_primary_has_two_values():

--- a/screeninfo/test_screeninfo.py
+++ b/screeninfo/test_screeninfo.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 import pytest
 
-from screeninfo import get_monitors
+from screeninfo import get_monitors, get_primary
 
 
 @contextmanager
@@ -21,3 +21,12 @@ def test_get_monitors_does_not_raise():
 def test_get_monitors_has_at_least_one_monitor():
     # GitHub actions have no physical monitors
     assert len(list(get_monitors())) >= 0
+
+
+def test_get_primary_does_not_raise():
+    with not_raises(Exception):
+        assert (get_primary()[0] * 0, get_primary()[1] * 0) == (0, 0)
+
+
+def test_get_primary_has_two_values():
+    assert len(tuple(get_primary())) == 2


### PR DESCRIPTION
This would be an useful function for the **primary** usage of this package: to get the width and height of the primary monitor.