### PR TITLE
Fix implicit call get monitors returning empty on OSX

### DIFF
--- a/screeninfo/screeninfo.py
+++ b/screeninfo/screeninfo.py
@@ -28,7 +28,9 @@ def get_monitors(
 
     for enumerator in Enumerator:
         try:
-            return _get_monitors(enumerator)
+            result = _get_monitors(enumerator)
+            assert result
+            return result
         except Exception:
             pass
 

--- a/screeninfo/test_screeninfo.py
+++ b/screeninfo/test_screeninfo.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import contextmanager
 
 import pytest
@@ -18,6 +19,9 @@ def test_get_monitors_does_not_raise():
         list(get_monitors())
 
 
+@pytest.mark.skipif(
+    os.environ.get("CI") == "true",
+    reason="GitHub actions have no physical monitors",
+)
 def test_get_monitors_has_at_least_one_monitor():
-    # GitHub actions have no physical monitors
-    assert len(list(get_monitors())) >= 0
+    assert len(list(get_monitors())) > 0


### PR DESCRIPTION
Fixes: https://github.com/rr-/screeninfo/issues/58

tl;dr, at the moment we have:

```py
>>> from screeninfo import get_monitors, Enumerator
>>> get_monitors()
[]
>>> get_monitors(Enumerator.OSX)
[Monitor(x=0, y=0, width=1680, height=1050, width_mm=None, height_mm=None, name=None)]
```

And test does detect this error because was not well configured to skip on github ci.

This PR fixes that by asserting the returned has len