### PR TITLE
DRM-Enumerator: Raise exception after checked all devices

### DIFF
--- a/screeninfo/enumerators/drm.py
+++ b/screeninfo/enumerators/drm.py
@@ -237,6 +237,7 @@ def enumerate_monitors() -> T.Iterable[Monitor]:
             prefix = "Unknown"
         return f"{prefix}-{connector.connector_type_id}"
 
+    got_resources = False
     for card_no in range(DRM_MAX_MINOR):
         card_path = DRM_DEV_NAME % (DRM_DIR_NAME, card_no)
         try:
@@ -249,7 +250,8 @@ def enumerate_monitors() -> T.Iterable[Monitor]:
         try:
             res = libdrm.drmModeGetResources(fd)
             if not res:
-                raise ScreenInfoError("Failed to get drm resources")
+                continue
+            got_resources = True
 
             res = res.contents
             res.fd = fd
@@ -270,3 +272,6 @@ def enumerate_monitors() -> T.Iterable[Monitor]:
 
         finally:
             os.close(fd)
+
+    if not got_resources:
+        raise ScreenInfoError("Failed to get drm resources")


### PR DESCRIPTION
DRM-Enumerator: Raise "failed to get resources" exception only after checked all devices

Issue: On a raspberry I have card0 and card1 in /dev/dri. The problem is that the enumerator fails to get the resources from card0 and raises an exception, thus it never checks card1 which supplies the correct resources.

This commit is meant to fix this issue.