### PR TITLE
add get_primary_monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,19 @@ for m in get_monitors():
     print(str(m))
 ```
 
+```python
+from screeninfo import get_primary_monitor
+print(str(get_primary_monitor()))
+```
+
 **Output**:
 
 ```python console
 Monitor(x=3840, y=0, width=3840, height=2160, width_mm=1420, height_mm=800, name='HDMI-0', is_primary=False)
+Monitor(x=0, y=0, width=3840, height=2160, width_mm=708, height_mm=399, name='DP-0', is_primary=True)
+```
+
+```python console
 Monitor(x=0, y=0, width=3840, height=2160, width_mm=708, height_mm=399, name='DP-0', is_primary=True)
 ```
 

--- a/screeninfo/__init__.py
+++ b/screeninfo/__init__.py
@@ -1,9 +1,10 @@
 from .common import Enumerator, Monitor
-from .screeninfo import ScreenInfoError, get_monitors
+from .screeninfo import ScreenInfoError, get_monitors, get_primary_monitor
 
 __all__ = [
     "Enumerator",
     "Monitor",
     "ScreenInfoError",
     "get_monitors",
+    "get_primary_monitor",
 ]

--- a/screeninfo/screeninfo.py
+++ b/screeninfo/screeninfo.py
@@ -30,3 +30,7 @@ def get_monitors(
             return monitors
 
     raise ScreenInfoError("No enumerators available")
+
+def get_primary_monitor() -> Monitor:
+    """Returns the primary monitor by :class:`Monitor`."""
+    return [m for m in get_monitors() if m.is_primary][0]


### PR DESCRIPTION
# Modified

## screeninfo/__init__.py
- Included `get_primary_monitor` into `__all__`

## screeninfo/screeninfo.py
- add function `get_primary_monitor` that filters the result of `get_monitors` to get the primary monitor

## README.md
- add the example usage of `get_primary_monitor`